### PR TITLE
[README]: re-word mailing list section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitPub is a decentralized federation protocol based on the W3C's [ActivityPub][ActivityPub], which
 extends [ActivityStream 2.0][ActivityStream2]. It provides a server to server API for pull request,
-forking and subscription of repositories provided by Git web services (services like Github, Gitlab, 
+forking and subscription of repositories provided by Git web services (services like GitHub, GitLab, 
 Gogs, Gitea).
 
 [ActivityPub]: https://www.w3.org/TR/activitypub/
@@ -14,21 +14,21 @@ A specification like this must be agreed upon by at least some of Git web servic
 If you are a developer of such a software, please [join our discussion][work-group-discussion] and speak up.
 We'll simply add you to the work group.
 
-If you are experienced in writing specifications, you're also welcomed to join the effort.
+If you are experienced in writing specifications, you're also welcome to join the effort.
 
 ## Mailing List Archive
 
-We're still waiting for all the tentive work group member to join the mailing list.
+We're still waiting for all the tentative work group members to join the mailing list.
 
-All major discussion and decision making will happen in our [Famalistes](https://framalistes.org/)
+All major discussion and decision making will happen in our [Framalistes](https://framalistes.org/)
 [mailing list](https://framalistes.org/sympa/info/git-federation). You may send us a mail at
-git-federation@framalistes.org. We do not garuntee to read all the mail but we would try.
+git-federation@framalistes.org. We do not guarantee to read all the mail but we will try.
 
 ## License
 
-The specification documents are licensed to a variation of [W3C Document License][w3c-document-license]. 
+The specification documents are licensed under a variation of the [W3C Document License][w3c-document-license]. 
 You may obtain a copy of the document license [here](LICENSES/DOCUMENT_LICENSE.md). The code
-components in this specification are licensed to MIT License. You may obtain a copy of the
+components in this specification are licensed under the MIT License. You may obtain a copy of the
 license [here](LICENSE/SOFTWARE_LICENSE.md).
 
 [w3c-document-license]: https://www.w3.org/Consortium/Legal/2015/doc-license

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ We'll simply add you to the work group.
 
 If you are experienced in writing specifications, you're also welcome to join the effort.
 
-## Mailing List Archive
+## Mailing List
 
 We're still waiting for all the tentative work group members to join the mailing list.
 
-All major discussion and decision making will happen in our [Framalistes](https://framalistes.org/)
-[mailing list](https://framalistes.org/sympa/info/git-federation). You may send us a mail at
-git-federation@framalistes.org. We do not guarantee to read all the mail but we will try.
+All major discussion and decision making will happen in our Framalistes
+[mailing list][mailing-list-archive].
+Non-members may use the GitHub issue tracker or send us a mail at:
+[git-federation@framalistes.org][mailing-list-address].
+We can not guarantee to read all mail or GitHub comments; but we will try.
 
 ## License
 
@@ -33,3 +35,5 @@ license [here](LICENSE/SOFTWARE_LICENSE.md).
 
 [w3c-document-license]: https://www.w3.org/Consortium/Legal/2015/doc-license
 [work-group-discussion]: https://github.com/git-federation/gitpub/issues/5
+[mailing-list-archive]: https://framalistes.org/sympa/arc/git-federation
+[mailing-list-address]: mailto://git-federation@framalistes.org


### PR DESCRIPTION
i would word this section more like this

i also changed the mailing link to point directly to the archives

NOTE: this commit is based on top of by Arkanosis' corrections in PR #13

im not sure why you invited non-members to send email - i thought you were trying to avoid that - but i should point out that the task of monitoring non-member emails it is essentially the same as if people were asked to subscribe to the mailing list themselves on the frama website

https://framalistes.org/sympa/subscribe/git-federation

in both cases, whether a non-member sends mail or subscribes to the list on the frama website; no message will get through to the list until approved manually in the moderation queue - so you could just as well change the link to issue #5 "join the discussion" to point to the subscribe page instead - that seems like it would save a step for you - then issue #5 could probably be closed as that was its only purpose
